### PR TITLE
fix(Sieve): every response is one step behind #1

### DIFF
--- a/library/Zend/Mail/Protocol/Sieve.php
+++ b/library/Zend/Mail/Protocol/Sieve.php
@@ -130,6 +130,9 @@ class Zend_Mail_Protocol_Sieve
                 }
                 throw new Zend_Mail_Protocol_Exception("cannot enable TLS: $message");
             }
+            if ($this->_implementation == 'Dovecot Pigeonhole') {
+                $this->readResponse();
+            }
         }
         
         return $this->_welcome;


### PR DESCRIPTION
... If you're using starttls with sieve and dovecot

fixes #1

Dovecot sends a response after enable encryption with
 stream_socket_enable_crypto. If this response is not handled all
 following responses are one step behind.

This cause a problem when requesting the capabilities of the sieve
 Server. The capabilities are always empty.

The provided patch resolve this issue.

- patch provided by by.erik -

see https://github.com/tine20/tine20/issues/6820