### PR TITLE
fix(Registry): make registry php 7.4 compatible

### DIFF
--- a/library/Zend/Registry.php
+++ b/library/Zend/Registry.php
@@ -194,16 +194,4 @@ class Zend_Registry extends ArrayObject
     {
         parent::__construct($array, $flags);
     }
-
-    /**
-     * @param string $index
-     * @returns mixed
-     *
-     * Workaround for http://bugs.php.net/bug.php?id=40442 (ZF-960).
-     */
-    public function offsetExists($index)
-    {
-        return array_key_exists($index, $this);
-    }
-
 }


### PR DESCRIPTION
Deprecated: array_key_exists(): Using array_key_exists()
 on objects is deprecated. Use isset() or property_exists()
 instead

see https://github.com/tine20/tine20/issues/7125