### PR TITLE
fix(Ldap/Converter): suppress chr() warning message

### DIFF
--- a/library/Zend/Ldap/Converter.php
+++ b/library/Zend/Ldap/Converter.php
@@ -83,7 +83,7 @@ class Zend_Ldap_Converter
      */
     private static function _charHex32ToAsc(array $matches)
     {
-        return chr(hexdec($matches[0]));
+        return @chr(hexdec($matches[0]));
     }
 
     /**


### PR DESCRIPTION
... as this might be problematic in php 7.4