### PR TITLE
tweak(Mail/Protocol): prevent fputs type error

### DIFF
--- a/library/Zend/Mail/Protocol/Imap.php
+++ b/library/Zend/Mail/Protocol/Imap.php
@@ -436,7 +436,7 @@ class Zend_Mail_Protocol_Imap
         }
 
         $this->_log(__METHOD__ . '::' . __LINE__ . ' IMAP request: ' . $line);
-        if (@fputs($this->_socket, $line . "\r\n") === false) {
+        if ($this->_socket === false || @fputs($this->_socket, $line . "\r\n") === false) {
             /**
              * @see Zend_Mail_Protocol_Exception
              */


### PR DESCRIPTION
"fputs(): Argument #1 ($stream) must be of type resource, bool given"