### PR TITLE
fix(Pdf/Resource/Font): use correct property name

### DIFF
--- a/library/Zend/Pdf/Resource/Font/CidFont.php
+++ b/library/Zend/Pdf/Resource/Font/CidFont.php
@@ -98,7 +98,7 @@ abstract class Zend_Pdf_Resource_Font_CidFont extends Zend_Pdf_Resource_Font
 
         $this->_isBold       = $fontParser->isBold;
         $this->_isItalic     = $fontParser->isItalic;
-        $this->_isMonospaced = $fontParser->isMonospaced;
+        $this->_isMonospace = $fontParser->isMonospaced;
 
         $this->_underlinePosition  = $fontParser->underlinePosition;
         $this->_underlineThickness = $fontParser->underlineThickness;

--- a/library/Zend/Pdf/Resource/Font/Simple/Parsed.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Parsed.php
@@ -61,7 +61,7 @@ abstract class Zend_Pdf_Resource_Font_Simple_Parsed extends Zend_Pdf_Resource_Fo
 
         $this->_isBold       = $fontParser->isBold;
         $this->_isItalic     = $fontParser->isItalic;
-        $this->_isMonospaced = $fontParser->isMonospaced;
+        $this->_isMonospace = $fontParser->isMonospaced;
 
         $this->_underlinePosition  = $fontParser->underlinePosition;
         $this->_underlineThickness = $fontParser->underlineThickness;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/Courier.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/Courier.php
@@ -97,7 +97,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_Courier extends Zend_Pdf_Resource_F
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBold.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBold.php
@@ -98,7 +98,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_CourierBold extends Zend_Pdf_Resour
 
         $this->_isBold = true;
         $this->_isItalic = false;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBoldOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBoldOblique.php
@@ -99,7 +99,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_CourierBoldOblique extends Zend_Pdf
 
         $this->_isBold = true;
         $this->_isItalic = true;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierOblique.php
@@ -99,7 +99,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_CourierOblique extends Zend_Pdf_Res
 
         $this->_isBold = false;
         $this->_isItalic = true;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/Helvetica.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/Helvetica.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_Helvetica extends Zend_Pdf_Resource
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBold.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBold.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaBold extends Zend_Pdf_Reso
 
         $this->_isBold = true;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
@@ -110,7 +110,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaBoldOblique extends Zend_P
 
         $this->_isBold = true;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaOblique.php
@@ -109,7 +109,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaOblique extends Zend_Pdf_R
 
         $this->_isBold = false;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/Symbol.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/Symbol.php
@@ -227,7 +227,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_Symbol extends Zend_Pdf_Resource_Fo
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBold.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBold.php
@@ -106,7 +106,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_TimesBold extends Zend_Pdf_Resource
 
         $this->_isBold = true;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBoldItalic.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBoldItalic.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_TimesBoldItalic extends Zend_Pdf_Re
 
         $this->_isBold = true;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesItalic.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesItalic.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_TimesItalic extends Zend_Pdf_Resour
 
         $this->_isBold = false;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesRoman.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesRoman.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_TimesRoman extends Zend_Pdf_Resourc
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/ZapfDingbats.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/ZapfDingbats.php
@@ -247,7 +247,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_ZapfDingbats extends Zend_Pdf_Resou
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Type0.php
+++ b/library/Zend/Pdf/Resource/Font/Type0.php
@@ -117,7 +117,7 @@ class Zend_Pdf_Resource_Font_Type0 extends Zend_Pdf_Resource_Font
 
         $this->_isBold       = $descendantFont->isBold();
         $this->_isItalic     = $descendantFont->isItalic();
-        $this->_isMonospaced = $descendantFont->isMonospace();
+        $this->_isMonospace = $descendantFont->isMonospace();
 
         $this->_underlinePosition  = $descendantFont->getUnderlinePosition();
         $this->_underlineThickness = $descendantFont->getUnderlineThickness();


### PR DESCRIPTION
fixes php 8.2 issue:

"Creation of dynamic property Zend_Pdf_Resource_Font_Simple_Standard_Helvetica::$_isMonospaced is deprecated"